### PR TITLE
Split Fiction workaround

### DIFF
--- a/src/dxmt/dxmt_context.hpp
+++ b/src/dxmt/dxmt_context.hpp
@@ -30,7 +30,7 @@
 namespace dxmt {
 
 constexpr size_t kCommandChunkCPUHeapSize = 0x1000000;
-constexpr size_t kCommandChunkGPUHeapSize = 0x400000;
+constexpr size_t kCommandChunkGPUHeapSize = 0x1000000;
 
 inline std::size_t
 align_forward_adjustment(const void *const ptr, const std::size_t &alignment) noexcept {


### PR DESCRIPTION
kCommandChunkGPUHeapSize to 0x1000000